### PR TITLE
Update Deploy Concurrency Group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,8 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [build-website, test-cdk]
-    concurrency: aws-deploy-step
+    concurrency: 
+      group: ${{ github.ref }}
     env:
       ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
       AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
This PR updates the deploy step concurrency group to allow deployment concurrency to be isolated to the particular branch.

I.e. `my-feature1` branch doesn't have to wait for `my-feature2` branch to deploy